### PR TITLE
Stop losing the second alarm, and fix three UI faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to LocReminder are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.7.0] - 2026-08-22
+## [1.7.0] - 2026-08-23
 
 ### Fixed
 - With two alarms armed, the second could stay silent for the whole journey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to LocReminder are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.0] - 2026-08-22
+
+### Fixed
+- With two alarms armed, the second could stay silent for the whole journey
+  and then ring on the way back past it. Two separate faults each caused
+  exactly that, and both are fixed.
+
+  The first was arrival state living in memory. An alarm rings on crossing
+  *into* its radius, so one set for where you are standing has to wait until
+  you leave and return, and deciding that needs a record of where you have
+  been. That record was two fields on the watch service. The service is
+  restarted automatically if Android kills it, which aggressive battery
+  managers do routinely and most of all right after a full-screen alarm takes
+  over the phone. It came back with the record erased, so the next location
+  fix looked like the first one ever taken, and any alarm you were already
+  approaching was filed as "we started inside this one" and held back until
+  the next time you left its radius. The record is now saved to disk.
+
+  The second was a second arrival landing while the first alarm was still
+  ringing. It was discarded outright, and because the alarm is only removed
+  from the armed list further along, it was left armed as well: silently
+  swallowed, then rung on re-entry. Arrivals now fold into the ring already
+  in progress, name both stops, and restart the ten-minute cutoff from the
+  newer arrival.
+- Vibration was suppressed by Do Not Disturb and the silent profile. It did
+  not declare itself as an alarm, so Android treated it as an ordinary
+  notification buzz and muted it — leaving the phone playing the tone while
+  sitting perfectly still in a pocket, which is the exact case vibration
+  exists for. It now also uses the current vibrator API on Android 12 and
+  above, and checks the phone has a vibrator before trying.
+- Messages appeared in the middle of the map and looked stuck there. A
+  floating message is laid out above whatever sits in the corner button slot,
+  and that slot held a column of three buttons rather than one, which pushed
+  every message a quarter of the way up the screen. Messages also queued
+  behind each other, so a burst played back one at a time long after the
+  action that caused it. Only one shows at a time now, at the bottom, for at
+  most five seconds.
+- Tapping the search bar took two taps to start typing. The first opened the
+  search screen with the field unfocused, so the keyboard needed a second tap
+  on a field you had in effect already tapped. It now opens ready to type.
+  "Add alarm" still opens on the map, since that asks for a place rather than
+  a name.
+
+### Added
+- Location checks now account for how fast you are moving. The intervals were
+  based on distance alone, which assumes a speed — and on a highway coach or
+  an intercity train it assumes far too low a one. At 108 km/h the app could
+  travel 600 m between two checks, enough to cross a small alarm area without
+  ever noticing. Where the phone reports a speed, the interval is also worked
+  out from how long is left until arrival, and the tighter of the two wins.
+- The alarm area now opens wider than 500 m when you set an alarm while
+  already travelling fast, and says why. Above 90 km/h it starts at 1 km,
+  above 50 at 500 m, above 25 at 300 m. Drag it back below that and it warns
+  you the alarm may pass your stop between checks.
+
+### Documentation
+- `docs/LOCALISATION.md` records what adding a language would take: the
+  inventory of every translatable string, where each has to live, and the
+  parts that are not just moving text.
+
 ## [1.6.16] - 2026-08-22
 
 ### Fixed

--- a/android/app/src/main/kotlin/com/zaifears/locreminder/AlarmActivity.kt
+++ b/android/app/src/main/kotlin/com/zaifears/locreminder/AlarmActivity.kt
@@ -21,8 +21,7 @@ class AlarmActivity : Activity() {
         setupWindowFlags()
         setContentView(R.layout.activity_alarm)
 
-        val label = intent.getStringExtra(AlarmForegroundService.EXTRA_LABEL) ?: "your destination"
-        findViewById<TextView>(R.id.alarmLabel).text = getString(R.string.alarm_arrived_message, label)
+        showLabelFrom(intent)
 
         findViewById<Button>(R.id.stopButton).setOnClickListener {
             startService(
@@ -32,6 +31,25 @@ class AlarmActivity : Activity() {
             )
             finish()
         }
+    }
+
+    // Launched SINGLE_TOP, so a second arrival while this is already up
+    // arrives here rather than through onCreate. Without this the screen kept
+    // naming only the first stop while the service had already folded in the
+    // second, which reads as the new alarm having been missed.
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.let {
+            setIntent(it)
+            showLabelFrom(it)
+        }
+    }
+
+    private fun showLabelFrom(source: Intent) {
+        val label = source.getStringExtra(AlarmForegroundService.EXTRA_LABEL)
+            ?: getString(R.string.alarm_default_destination)
+        findViewById<TextView>(R.id.alarmLabel).text =
+            getString(R.string.alarm_arrived_message, label)
     }
 
     private fun setupWindowFlags() {

--- a/android/app/src/main/kotlin/com/zaifears/locreminder/AlarmForegroundService.kt
+++ b/android/app/src/main/kotlin/com/zaifears/locreminder/AlarmForegroundService.kt
@@ -15,6 +15,7 @@ import android.os.Looper
 import android.os.PowerManager
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.os.VibratorManager
 import android.util.Log
 import androidx.core.app.NotificationCompat
 
@@ -34,6 +35,9 @@ class AlarmForegroundService : Service() {
     private var wakeLock: PowerManager.WakeLock? = null
     private val handler = Handler(Looper.getMainLooper())
     private var autoStopRunnable: Runnable? = null
+
+    /** Every destination this ring covers, in arrival order. */
+    private val ringingLabels = mutableListOf<String>()
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -61,17 +65,47 @@ class AlarmForegroundService : Service() {
     }
 
     private fun startAlarm(alarmId: String, label: String) {
-        if (isRinging) return
+        // A second arrival landing mid-ring used to be dropped here, and
+        // because the entry is consumed further down it was left armed too.
+        // Two alarms close enough together that the first was still ringing
+        // therefore lost the second outright: it stayed silent for the rest
+        // of the journey and only went off on the way back past it, once the
+        // user had left its radius and re-entered. Fold it into the ring that
+        // is already happening instead of discarding it.
+        if (isRinging) {
+            Log.i(TAG, "Already ringing; folding in $label")
+            if (label !in ringingLabels) ringingLabels.add(label)
+            consumeAlarm(alarmId)
+            startForeground(NOTIFICATION_ID, buildNotification(ringingLabel(), alarmId))
+            // Re-delivered to the activity too, so the screen names both
+            // stops instead of only the one that got there first.
+            launchAlarmActivity(ringingLabel(), alarmId)
+            // The user has only just arrived somewhere new, so give them the
+            // full ten minutes from *this* arrival rather than the first.
+            autoStopRunnable?.let { handler.removeCallbacks(it) }
+            scheduleAutoStop()
+            return
+        }
+
         isRinging = true
+        ringingLabels.clear()
+        ringingLabels.add(label)
 
         NotificationHelper.ensureAlarmChannel(this)
-        startForeground(NOTIFICATION_ID, buildNotification(label, alarmId))
+        startForeground(NOTIFICATION_ID, buildNotification(ringingLabel(), alarmId))
         acquireWakeLock()
         launchAlarmActivity(label, alarmId)
         playAlarmSound()
         startVibration()
         scheduleAutoStop()
         consumeAlarm(alarmId)
+    }
+
+    /** What the notification calls this ring, once it may cover more than one stop. */
+    private fun ringingLabel(): String = when (ringingLabels.size) {
+        0 -> "your destination"
+        1 -> ringingLabels.first()
+        else -> ringingLabels.joinToString(" and ")
     }
 
     /**
@@ -113,6 +147,7 @@ class AlarmForegroundService : Service() {
         wakeLock = null
 
         isRinging = false
+        ringingLabels.clear()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             stopForeground(STOP_FOREGROUND_REMOVE)
         } else {
@@ -180,13 +215,42 @@ class AlarmForegroundService : Service() {
 
     private fun startVibration() {
         if (!AlarmSettings(this).vibrationEnabled()) return
-        vibrator = getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
-        val pattern = longArrayOf(0, 800, 400)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator?.vibrate(VibrationEffect.createWaveform(pattern, 0))
+
+        // VIBRATOR_SERVICE still resolves on Android 12+, but through a
+        // compatibility shim; VibratorManager is the real accessor there.
+        val device = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager)?.defaultVibrator
         } else {
             @Suppress("DEPRECATION")
-            vibrator?.vibrate(pattern, 0)
+            getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        }
+
+        if (device == null || !device.hasVibrator()) {
+            Log.i(TAG, "No vibrator available; ringing without it")
+            return
+        }
+        vibrator = device
+
+        // Declared as an alarm rather than left to default to USAGE_UNKNOWN.
+        // Do Not Disturb and the silent profile suppress ordinary vibrations,
+        // so without these attributes the phone would play the tone on the
+        // alarm stream while sitting perfectly still in a pocket — which is
+        // exactly the situation the buzz exists for.
+        val attributes = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_ALARM)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .build()
+
+        val pattern = longArrayOf(0, 800, 400)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                device.vibrate(VibrationEffect.createWaveform(pattern, 0), attributes)
+            } else {
+                @Suppress("DEPRECATION")
+                device.vibrate(pattern, 0, attributes)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Vibration failed; the tone still plays", e)
         }
     }
 

--- a/android/app/src/main/kotlin/com/zaifears/locreminder/AlarmForegroundService.kt
+++ b/android/app/src/main/kotlin/com/zaifears/locreminder/AlarmForegroundService.kt
@@ -82,8 +82,13 @@ class AlarmForegroundService : Service() {
             launchAlarmActivity(ringingLabel(), alarmId)
             // The user has only just arrived somewhere new, so give them the
             // full ten minutes from *this* arrival rather than the first.
+            // Both timers, not just the visible one: the wake lock was taken
+            // out when the first alarm began, so a fold nine minutes in would
+            // otherwise let the CPU sleep a minute later with the alarm
+            // still ringing.
             autoStopRunnable?.let { handler.removeCallbacks(it) }
             scheduleAutoStop()
+            acquireWakeLock()
             return
         }
 
@@ -162,7 +167,9 @@ class AlarmForegroundService : Service() {
         super.onDestroy()
     }
 
+    /** Takes the wake lock, replacing any already held so the timeout restarts. */
     private fun acquireWakeLock() {
+        wakeLock?.let { if (it.isHeld) it.release() }
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
         wakeLock = powerManager.newWakeLock(
             PowerManager.PARTIAL_WAKE_LOCK,

--- a/android/app/src/main/kotlin/com/zaifears/locreminder/ArrivalState.kt
+++ b/android/app/src/main/kotlin/com/zaifears/locreminder/ArrivalState.kt
@@ -1,0 +1,88 @@
+package com.zaifears.locreminder
+
+import android.content.Context
+
+/**
+ * Remembers, across process death, which alarms the user has been seen
+ * outside of.
+ *
+ * An alarm rings on *crossing into* its radius, so an alarm set for where you
+ * are standing must stay quiet until you leave and return. Deciding that
+ * needs a memory of where the user has been, and until 1.7.0 that memory was
+ * two ordinary fields on [LocationWatchService].
+ *
+ * That was the bug behind a missed alarm. The watch service is START_STICKY,
+ * so when an aggressive OEM memory manager killed the app mid-journey — most
+ * likely of all right after a full-screen alarm took over the screen — the
+ * system brought the service straight back with both fields reset. The next
+ * fix therefore looked like the very first one, and any *other* alarm the
+ * user happened to already be approaching was filed as "we started inside
+ * this one" and suppressed. It then stayed silent for the rest of the trip
+ * and rang on the return leg, when the user finally left the radius and
+ * re-entered it.
+ *
+ * Persisting the state fixes it at the root: a restart no longer erases what
+ * the service already knew about an alarm.
+ */
+class ArrivalState(context: Context) {
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * Whether [id] must be exited before it may ring, recording the first
+     * sighting as a side effect.
+     *
+     * Called only for a fix that actually places the user inside the radius.
+     * The first time an alarm is ever seen, being inside means the user set it
+     * for where they already are, so it is suppressed. Every time after that
+     * the answer comes from what was persisted, which is what makes it
+     * survive a restart.
+     */
+    fun shouldSuppress(id: String): Boolean {
+        val seen = read(KEY_SEEN)
+        if (id !in seen) {
+            write(KEY_SEEN, seen + id)
+            write(KEY_SUPPRESSED, read(KEY_SUPPRESSED) + id)
+            return true
+        }
+        return id in read(KEY_SUPPRESSED)
+    }
+
+    /** Records that the user is outside [id], which clears any suppression. */
+    fun markOutside(id: String) {
+        val seen = read(KEY_SEEN)
+        if (id !in seen) write(KEY_SEEN, seen + id)
+
+        val suppressed = read(KEY_SUPPRESSED)
+        if (id in suppressed) write(KEY_SUPPRESSED, suppressed - id)
+    }
+
+    /**
+     * Drops state for alarms that no longer exist, so deleting and re-adding
+     * an alarm for the same place behaves like the new alarm it is rather
+     * than inheriting the old one's suppression.
+     */
+    fun forgetAllExcept(liveIds: Collection<String>) {
+        val live = liveIds.toSet()
+        for (key in arrayOf(KEY_SEEN, KEY_SUPPRESSED)) {
+            val kept = read(key).intersect(live)
+            if (kept.size != read(key).size) write(key, kept)
+        }
+    }
+
+    private fun read(key: String): Set<String> =
+        prefs.getStringSet(key, emptySet())?.toSet() ?: emptySet()
+
+    private fun write(key: String, value: Set<String>) {
+        // A fresh set every time, deliberately: SharedPreferences does not
+        // copy the set it is handed, so mutating a previously stored instance
+        // corrupts the in-memory cache without ever reaching disk.
+        prefs.edit().putStringSet(key, HashSet(value)).apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "locreminder_arrival_state"
+        const val KEY_SEEN = "seen"
+        const val KEY_SUPPRESSED = "suppressed"
+    }
+}

--- a/android/app/src/main/kotlin/com/zaifears/locreminder/LocationWatchService.kt
+++ b/android/app/src/main/kotlin/com/zaifears/locreminder/LocationWatchService.kt
@@ -37,9 +37,12 @@ class LocationWatchService : Service() {
     private var nearestLabel: String? = null
     private var nearestDistance: Double? = null
 
-    /** Alarms the user was already inside, which must be exited before they can trigger. */
-    private val suppressedUntilExit = mutableSetOf<String>()
-    private var hadFirstFix = false
+    /**
+     * Which alarms have been seen from outside, and so may ring on the way
+     * back in. Persisted rather than held in fields: see [ArrivalState] for
+     * the missed alarm that taught us the difference.
+     */
+    private val arrivalState by lazy { ArrivalState(this) }
 
     private val locationListener = object : LocationListener {
         override fun onLocationChanged(location: Location) = onLocation(location)
@@ -171,6 +174,8 @@ class LocationWatchService : Service() {
             return
         }
 
+        arrivalState.forgetAllExcept(entries.map { it.id })
+
         var closest: Pair<AlarmEntry, Double>? = null
 
         for (entry in entries) {
@@ -192,30 +197,30 @@ class LocationWatchService : Service() {
                 // proximity has already tightened the polling interval.
                 if (!canConfirmArrival(location, entry.radius)) {
                     Log.i(TAG, "Ignoring ${location.accuracy}m fix for ${entry.label}")
-                } else if (!hadFirstFix || entry.id in suppressedUntilExit) {
+                } else if (arrivalState.shouldSuppress(entry.id)) {
                     // Arrival means crossing *into* the radius. Being inside
-                    // already when watching starts is not an arrival, so an
-                    // alarm set for where you're standing doesn't ring at once.
-                    suppressedUntilExit.add(entry.id)
+                    // already the first time this alarm is seen is not an
+                    // arrival, so an alarm set for where you're standing
+                    // doesn't ring at once.
+                    Log.i(TAG, "Inside ${entry.label} but not arrived; awaiting exit")
                 } else {
                     triggerAlarm(entry)
                     return
                 }
             } else {
-                suppressedUntilExit.remove(entry.id)
+                arrivalState.markOutside(entry.id)
             }
 
             if (closest == null || distance < closest.second) {
                 closest = entry to distance
             }
         }
-        hadFirstFix = true
 
         closest?.let { (entry, distance) ->
             nearestLabel = entry.label
             nearestDistance = distance
             updateNotification()
-            adaptIntervalTo(distance)
+            adaptIntervalTo(distance, location)
         }
     }
 
@@ -239,14 +244,32 @@ class LocationWatchService : Service() {
      * country would flatten the battery on a long journey for no benefit,
      * while two-minute fixes 200m out would sail past the stop.
      */
-    private fun adaptIntervalTo(distanceMetres: Double) {
-        val target = when {
+    private fun adaptIntervalTo(distanceMetres: Double, location: Location) {
+        val byDistance = when {
             distanceMetres > 10_000 -> VERY_FAR_INTERVAL_MILLIS
             distanceMetres > 5_000 -> FAR_INTERVAL_MILLIS
             distanceMetres > 1_500 -> 60_000L
             distanceMetres > 500 -> 20_000L
             else -> NEAR_INTERVAL_MILLIS
         }
+
+        // Distance on its own assumes a speed, and on a highway coach or an
+        // intercity train it assumes far too low a one. At 30 m/s the 500m
+        // band's 20s interval covers 600m between consecutive fixes, so a
+        // tight radius can be crossed entirely without ever being sampled.
+        // Where the fix reports a speed, poll on time-to-arrival as well and
+        // take whichever of the two answers is tighter.
+        val speed = location.takeIf { it.hasSpeed() }?.speed?.takeIf { it > 1f }
+        val target = if (speed == null) {
+            byDistance
+        } else {
+            // A quarter of the remaining journey, so four fixes land between
+            // here and the destination however fast "here" happens to be.
+            val byEta = (distanceMetres / speed / 4 * 1000).toLong()
+                .coerceIn(NEAR_INTERVAL_MILLIS, VERY_FAR_INTERVAL_MILLIS)
+            minOf(byDistance, byEta)
+        }
+
         if (target != currentIntervalMillis) requestUpdates(target)
     }
 

--- a/android/app/src/main/kotlin/com/zaifears/locreminder/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/zaifears/locreminder/MainActivity.kt
@@ -363,7 +363,7 @@ class MainActivity : FlutterActivity() {
      * null rather than waiting for a fresh fix — the map has a sensible
      * default, and blocking the UI on GPS would be worse than showing it.
      */
-    private fun lastKnownLocation(): Map<String, Any>? {
+    private fun lastKnownLocation(): Map<String, Any?>? {
         val manager = getSystemService(LocationManager::class.java) ?: return null
 
         val providers = buildList {
@@ -389,10 +389,14 @@ class MainActivity : FlutterActivity() {
         return (best ?: return null).asMap()
     }
 
-    private fun android.location.Location.asMap(): Map<String, Any> = mapOf(
+    private fun android.location.Location.asMap(): Map<String, Any?> = mapOf(
         "latitude" to latitude,
         "longitude" to longitude,
         "accuracy" to accuracy.toDouble(),
+        // Metres per second, or null where the provider doesn't report it.
+        // The picker uses it to warn that a tight radius may be crossed
+        // between fixes at the speed the user is currently travelling.
+        "speed" to if (hasSpeed()) speed.toDouble() else null,
         // Lets the caller judge staleness. A cached fix can be hours old and
         // hundreds of kilometres away, which is worth showing differently
         // from a fix taken just now.
@@ -435,7 +439,7 @@ class MainActivity : FlutterActivity() {
         // won't smart-cast a var captured by a closure back to non-null.
         val registered = arrayOfNulls<android.location.LocationListener>(1)
 
-        fun settle(value: Map<String, Any>?) {
+        fun settle(value: Map<String, Any?>?) {
             if (settled) return
             settled = true
             registered[0]?.let { runCatching { manager.removeUpdates(it) } }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="alarm_arrived_default">You\'ve arrived!</string>
     <string name="alarm_arrived_message">You\'re near\n%1$s</string>
     <string name="alarm_stop_button">Stop alarm</string>
+    <string name="alarm_default_destination">your destination</string>
 </resources>

--- a/docs/LOCALISATION.md
+++ b/docs/LOCALISATION.md
@@ -1,0 +1,140 @@
+# Adding a language
+
+LocReminder is English-only today. This is the plan for changing that, and
+the inventory of everything a translator would have to touch.
+
+Nothing here is done yet. It is written down first because the shape of the
+work decides where the strings should live, and moving 350 strings twice is
+worse than moving them once.
+
+## What "easy to add a language" should mean
+
+The target: adding Bangla is **three files and no code**.
+
+```
+lib/l10n/app_bn.arb                              the app's own text
+android/app/src/main/res/values-bn/strings.xml   what the alarm says
+fastlane/metadata/android/bn/                    the F-Droid store listing
+```
+
+Add them, and the app follows the phone's language setting with no further
+changes. Nothing else should need editing, and nobody should need to be able
+to write Dart to contribute a translation.
+
+Three files rather than one because three different things render the text,
+and only one of them is Flutter:
+
+- The **app UI** is Flutter, so it uses Flutter's own localisation.
+- The **alarm** is deliberately not Flutter. It rings through a native
+  Activity and notification so it works when the Flutter engine is not
+  running, which means its text comes from Android resources.
+- The **store listing** is read by F-Droid from the repository, never by the
+  app at all.
+
+## Why ARB, and what it costs
+
+Flutter's standard is ARB — a JSON file per language under `lib/l10n`, with
+`flutter gen-l10n` turning them into a lookup class. It is worth using rather
+than hand-rolling a `Map<String, String>` for two reasons: Weblate, which is
+how translations actually reach a FOSS app, reads ARB natively; and plurals
+("1 alarm" against "5 alarms") are a real problem that ARB solves and a plain
+map does not.
+
+It has a cost worth stating plainly. It adds `flutter_localizations` and
+`intl` to the dependency set, which means:
+
+1. `pubspec.lock` has to be regenerated. CI builds with
+   `--enforce-lockfile`, so the build **will fail** until the
+   `refresh-lockfile` workflow has been run and its commit merged.
+2. It adds a code-generation step to the build. Reproducible builds took six
+   releases to get right, and F-Droid compares our APK to theirs byte for
+   byte. `gen-l10n` is deterministic, so this should be safe — but "should
+   be" has been wrong before on this project.
+
+Because of (2), the migration wants to be its own release, verified on its
+own. Do not fold it into a release that also carries alarm fixes.
+
+## The inventory
+
+350 or so distinct strings. The count is unique literals per file, so shared
+wording is counted once where it is written.
+
+### Flutter — 328 strings
+
+| File | Strings | Notes |
+|---|---:|---|
+| `lib/services/oem_service.dart` | 90 | Per-manufacturer battery-settings instructions. The largest single block by far, and the most valuable to translate: it is the text that stops alarms being silently killed. Names like "MIUI" and "HyperOS" stay untranslated. |
+| `lib/screens/onboarding_screen.dart` | 56 | First-run explanations of why each permission is needed. |
+| `lib/screens/home_screen.dart` | 39 | Map screen, alarm list, and every transient message. Contains the plurals and interpolations listed below. |
+| `lib/screens/reliability_screen.dart` | 36 | The "your alarms will not ring" diagnostics and their fixes. |
+| `lib/screens/about_screen.dart` | 25 | Includes the Free Palestine section. |
+| `lib/screens/settings_screen.dart` | 23 | |
+| `lib/screens/location_picker_screen.dart` | 20 | Search, radius, and the speed advice added in 1.7.0. |
+| `lib/widgets/alarm_sound_section.dart` | 13 | |
+| `lib/widgets/map_tiles.dart` | 11 | Map style names, and the note on why there is no satellite view. |
+| `lib/widgets/app_drawer.dart` | 6 | |
+| `lib/services/geocoding_service.dart` | 5 | Search failure messages. |
+| `lib/main.dart`, `lib/models/place_result.dart`, `lib/services/app_version.dart` | 4 | |
+
+### Android — 30 strings
+
+| File | Strings | Notes |
+|---|---:|---|
+| `NotificationHelper.kt` | 10 | Channel names and descriptions. These appear in Android's own settings UI, not just ours. |
+| `LocationWatchService.kt` | 8 | The ongoing notification: "1 alarm armed", "450 m from Home". Plural and interpolated. |
+| `AlarmForegroundService.kt` | 5 | "You're near X", and the joiner between two stops. |
+| `MainActivity.kt` | 6 | Mostly channel error messages; only "Test alarm" is user-visible. |
+| `AlarmSettings.kt` | 1 | "Custom sound" fallback name. |
+
+Three strings are already in `res/values/strings.xml` and are the model for
+the rest.
+
+### Store listing — 4 files
+
+`fastlane/metadata/android/en-US/`: `title.txt`, `short_description.txt`,
+`full_description.txt`, and `changelogs/`. F-Droid reads a sibling directory
+per locale. Changelogs are per-version and only worth translating going
+forward, not retroactively.
+
+## The parts that are not just moving text
+
+**Plurals.** "1 alarm" / "5 alarms" appears in the alarm sheet header and in
+the watch notification. Bangla does not inflect plurals the way English
+does, and other target languages have more than two forms. These must become
+ARB `plural` entries, not string concatenation.
+
+**Interpolation with units.** "450 m from Home" and "1.2 km from Home" put a
+number, a unit, and a place name in an order that is not universal. Keep the
+whole sentence as one translatable string with named placeholders, never
+assembled from fragments.
+
+**Distance formatting.** `formatDistance` picks m against km. The threshold
+is fine everywhere, but the decimal separator is not: much of Europe writes
+`1,2 km`. This needs `NumberFormat` from `intl`, which the migration pulls in
+anyway.
+
+**Right-to-left.** Not needed for Bangla, which is left-to-right. If Arabic
+or Urdu is ever added, every hardcoded `EdgeInsets.only(left:)` becomes a bug.
+Switching those to `EdgeInsetsDirectional` is cheap to do during the
+migration and expensive to retrofit.
+
+**What must not be translated.** Manufacturer and OS names (Xiaomi, MIUI,
+HyperOS, Samsung, OnePlus), the Android setting names the instructions tell
+users to look for — those appear in English on some ROMs regardless — map
+style names that are proper nouns (OpenStreetMap, OpenTopoMap), and the app
+name itself.
+
+## Order of work
+
+1. Add the dependencies and run `refresh-lockfile`. Merge that alone, and
+   confirm CI is green, before touching a single string.
+2. Move the Android strings into `res/values/strings.xml`. Self-contained,
+   30 strings, and it does not touch the Flutter build at all.
+3. Move the Flutter strings into `lib/l10n/app_en.arb`, file by file. Largest
+   first — `oem_service.dart` alone is a quarter of the total.
+4. Release, and verify the reproducible build still matches before adding any
+   actual translation.
+5. Only then add `app_bn.arb` and the rest.
+
+Steps 1 to 4 change no visible behaviour. That is the point: if the English
+build looks and reads identically before and after, the migration was clean.

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -36,6 +36,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   static const _sheetExpanded = 0.62;
   // Past this the sheet owns the screen and the map controls step aside.
   static const _controlsFadeAt = 0.30;
+  /// Ceiling for any transient message, in seconds.
+  static const _maxNoticeSeconds = 5;
 
   final _repository = AlarmRepository();
   final _nativeBridge = NativeBridge();
@@ -46,6 +48,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   LatLng _initialPosition = _defaultPosition;
   LatLng? _userLocation;
   double? _userAccuracy;
+  double? _userSpeed;
   PermissionStatusSummary? _permissions;
   bool _loading = true;
   bool _locating = false;
@@ -96,6 +99,26 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (mounted) setState(() => _permissions = status);
   }
 
+  /// Shows a transient message, replacing any message already on screen.
+  ///
+  /// Every notice goes through here for two reasons. SnackBars *queue* by
+  /// default, so a burst of them plays back one after another and the last is
+  /// still sitting there long after the action that caused it — which reads
+  /// as a stuck message rather than a slow one. And the longest message needs
+  /// a ceiling: [_maxNoticeSeconds] is long enough to read a two-line
+  /// sentence and short enough not to outstay the moment.
+  void _notify(String message, {SnackBarAction? action, int seconds = 3}) {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.of(context)..clearSnackBars();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        action: action,
+        duration: Duration(seconds: seconds.clamp(1, _maxNoticeSeconds)),
+      ),
+    );
+  }
+
   /// Keeps the native watch service running exactly while something is armed.
   /// Called after every change to the alarm list so the service never lingers
   /// with nothing to watch, and never stops while an alarm still needs it.
@@ -108,15 +131,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         await _nativeBridge.stopLocationWatch();
       }
     } on PlatformException catch (e) {
-      if (mounted && shouldWatch) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Background tracking could not start (${e.code}). Alarms may be '
-              'delayed — check permissions in Settings.',
-            ),
-            duration: const Duration(seconds: 6),
-          ),
+      if (shouldWatch) {
+        _notify(
+          'Background tracking could not start (${e.code}). Alarms may be '
+          'delayed — check permissions in Settings.',
+          seconds: 5,
         );
       }
     }
@@ -148,6 +167,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       setState(() {
         _userLocation = located;
         _userAccuracy = (fix?['accuracy'] as num?)?.toDouble();
+        _userSpeed = (fix?['speed'] as num?)?.toDouble();
         _initialPosition = located;
       });
       if (recenter) _mapController.move(located, 15);
@@ -164,20 +184,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     final locationOn = await _nativeBridge.isLocationEnabled();
     if (!mounted) return;
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          locationOn
-              ? "Couldn't get a location fix. Try again outdoors."
-              : 'Location is switched off.',
-        ),
-        action: locationOn
-            ? null
-            : SnackBarAction(
-                label: 'Turn on',
-                onPressed: _nativeBridge.openLocationSettings,
-              ),
-      ),
+    _notify(
+      locationOn
+          ? "Couldn't get a location fix. Try again outdoors."
+          : 'Location is switched off.',
+      action: locationOn
+          ? null
+          : SnackBarAction(
+              label: 'Turn on',
+              onPressed: _nativeBridge.openLocationSettings,
+            ),
     );
   }
 
@@ -200,11 +216,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       setState(() => _alarms = reconciled);
       await _repository.saveAll(_alarms);
       await _syncLocationWatch();
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Already rang: ${triggeredLabels.join(', ')}')),
-        );
-      }
+      _notify('Already rang: ${triggeredLabels.join(', ')}');
     }
   }
 
@@ -219,11 +231,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     await _refreshRingingState();
   }
 
-  Future<void> _addAlarm() async {
+  /// Opens the picker. [fromSearch] is set by the search field at the top of
+  /// the map, which is a request to type — so the keyboard comes up with the
+  /// screen rather than waiting for a second tap on a field the user has in
+  /// effect already tapped.
+  Future<void> _addAlarm({bool fromSearch = false}) async {
     final picked = await Navigator.of(context).push<PickedLocation>(
       MaterialPageRoute(
         builder: (_) => LocationPickerScreen(
           initialCenter: _userLocation ?? _initialPosition,
+          autofocusSearch: fromSearch,
+          travelSpeed: _userSpeed,
         ),
       ),
     );
@@ -256,16 +274,12 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         const Distance()(here, LatLng(alarm.latitude, alarm.longitude)) <=
             alarm.radiusMeters;
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          alreadyInside
-              ? "Alarm set — but you're already inside this area, so it will "
-                  'ring when you leave and come back.'
-              : 'Alarm set for ${alarm.label}',
-        ),
-        duration: Duration(seconds: alreadyInside ? 6 : 3),
-      ),
+    _notify(
+      alreadyInside
+          ? "Alarm set — but you're already inside this area, so it will ring "
+              'when you leave and come back.'
+          : 'Alarm set for ${alarm.label}',
+      seconds: alreadyInside ? 5 : 3,
     );
   }
 
@@ -276,11 +290,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       await _nativeBridge.addAlarm(alarm);
       return true;
     } on PlatformException catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Could not set alarm: ${e.message ?? e.code}')),
-        );
-      }
+      _notify('Could not set alarm: ${e.message ?? e.code}', seconds: 5);
       return false;
     }
   }
@@ -317,14 +327,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     await _syncLocationWatch();
     if (!mounted) return;
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Deleted ${alarm.label}'),
-        action: SnackBarAction(
-          label: 'Undo',
-          onPressed: () => _restoreAlarm(alarm, index),
-        ),
+    _notify(
+      'Deleted ${alarm.label}',
+      action: SnackBarAction(
+        label: 'Undo',
+        onPressed: () => _restoreAlarm(alarm, index),
       ),
+      seconds: 5,
     );
   }
 
@@ -422,14 +431,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   void _showAlarmPreview(LocationAlarm alarm) {
     final distance = _distanceTo(alarm);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          distance == null
-              ? '${alarm.label} · rings within ${formatDistance(alarm.radiusMeters)}'
-              : '${alarm.label} · ${formatDistance(distance)} away',
-        ),
-      ),
+    _notify(
+      distance == null
+          ? '${alarm.label} · rings within ${formatDistance(alarm.radiusMeters)}'
+          : '${alarm.label} · ${formatDistance(distance)} away',
     );
   }
 
@@ -514,63 +519,73 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 ),
               ),
             ),
+            _buildMapControls(context),
             _buildAlarmSheet(context),
           ],
         ),
       ),
-      // Rides just above the collapsed sheet, and gets out of the way as the
-      // sheet is dragged open: past that point the user is reading the list,
-      // not working the map, and three buttons floating over the rows are
-      // just something to hit by accident.
-      // Rides just above the collapsed sheet, and gets out of the way as the
-      // sheet is dragged open: past that point the user is reading the list,
-      // not working the map, and three buttons floating over the rows are
-      // just something to hit by accident.
-      floatingActionButton: IgnorePointer(
+    );
+  }
+
+  /// The map controls, positioned in the stack rather than handed to
+  /// [Scaffold.floatingActionButton].
+  ///
+  /// The slot would be the obvious home for them, but a floating SnackBar is
+  /// laid out *above* whatever occupies it, and this is a 240-pixel column of
+  /// three buttons, not one. Every message the app showed was therefore
+  /// launched into the middle of the map, nowhere near the bottom edge people
+  /// look at. Owning the position here puts messages back where they belong.
+  ///
+  /// They ride just above the collapsed sheet and get out of the way as it is
+  /// dragged open: past that point the user is reading the list, not working
+  /// the map, and buttons floating over the rows are just something to hit by
+  /// accident.
+  Widget _buildMapControls(BuildContext context) {
+    return Positioned(
+      right: 16,
+      bottom: _mapControlsBottomInset(context),
+      child: IgnorePointer(
         ignoring: _mapControlsHidden,
         child: AnimatedOpacity(
           opacity: _mapControlsHidden ? 0 : 1,
           duration: const Duration(milliseconds: 160),
           curve: Curves.easeOut,
-          child: Padding(
-            padding: EdgeInsets.only(bottom: _mapControlsBottomInset(context)),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              // End, not the default centre: the wide "Add alarm" button sets
-              // the column's width, so centred small buttons sit inset from
-              // the screen edge and read as misaligned against it.
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                FloatingActionButton.small(
-                  heroTag: 'style',
-                  tooltip: 'Map style',
-                  onPressed: _pickMapStyle,
-                  child: const Icon(Icons.layers_outlined),
-                ),
-                const SizedBox(height: 12),
-                FloatingActionButton.small(
-                  heroTag: 'locate',
-                  tooltip: 'Centre on my location',
-                  // Getting a real fix can take a few seconds, so the button
-                  // has to show it is working rather than looking inert.
-                  onPressed: _locating ? null : () => _locateUser(recenter: true),
-                  child: _locating
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.my_location),
-                ),
-                const SizedBox(height: 12),
-                FloatingActionButton.extended(
-                  heroTag: 'add',
-                  onPressed: _addAlarm,
-                  icon: const Icon(Icons.add_location_alt),
-                  label: const Text('Add alarm'),
-                ),
-              ],
-            ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            // End, not the default centre: the wide "Add alarm" button sets
+            // the column's width, so centred small buttons sit inset from
+            // the screen edge and read as misaligned against it.
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              FloatingActionButton.small(
+                heroTag: 'style',
+                tooltip: 'Map style',
+                onPressed: _pickMapStyle,
+                child: const Icon(Icons.layers_outlined),
+              ),
+              const SizedBox(height: 12),
+              FloatingActionButton.small(
+                heroTag: 'locate',
+                tooltip: 'Centre on my location',
+                // Getting a real fix can take a few seconds, so the button
+                // has to show it is working rather than looking inert.
+                onPressed: _locating ? null : () => _locateUser(recenter: true),
+                child: _locating
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.my_location),
+              ),
+              const SizedBox(height: 12),
+              FloatingActionButton.extended(
+                heroTag: 'add',
+                onPressed: _addAlarm,
+                icon: const Icon(Icons.add_location_alt),
+                label: const Text('Add alarm'),
+              ),
+            ],
           ),
         ),
       ),
@@ -600,7 +615,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               color: Theme.of(context).colorScheme.surface,
               child: InkWell(
                 borderRadius: BorderRadius.circular(16),
-                onTap: _addAlarm,
+                onTap: () => _addAlarm(fromSearch: true),
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
                   child: Row(

--- a/lib/screens/location_picker_screen.dart
+++ b/lib/screens/location_picker_screen.dart
@@ -6,6 +6,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../models/place_result.dart';
 import '../services/geocoding_service.dart';
+import '../services/radius_advice.dart';
 import '../widgets/map_pin.dart';
 import '../widgets/map_tiles.dart';
 
@@ -27,9 +28,26 @@ class PickedLocation {
 /// fixed centre crosshair. Replaces blind tapping — you can look up "Dhaka
 /// Airport" instead of hunting for it on the map.
 class LocationPickerScreen extends StatefulWidget {
-  const LocationPickerScreen({super.key, required this.initialCenter});
+  const LocationPickerScreen({
+    super.key,
+    required this.initialCenter,
+    this.autofocusSearch = false,
+    this.travelSpeed,
+  });
 
   final LatLng initialCenter;
+
+  /// Whether to raise the keyboard on arrival.
+  ///
+  /// True when the user tapped the search field on the map, where they have
+  /// already said what they want to do and a second tap to summon the
+  /// keyboard is pure friction. False when they tapped "Add alarm", which
+  /// asks for a place on the map, not a name.
+  final bool autofocusSearch;
+
+  /// The user's current speed in metres per second, where it is known.
+  /// Decides the starting radius: see [minimumRadiusForSpeed].
+  final double? travelSpeed;
 
   @override
   State<LocationPickerScreen> createState() => _LocationPickerScreenState();
@@ -53,8 +71,22 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   bool _resolvingAddress = false;
   Timer? _addressDebounce;
 
-  double _radius = 500;
+  late double _radius = _initialRadius();
   String? _chosenName;
+
+  /// Whether the starting radius was raised because of [widget.travelSpeed],
+  /// which is worth explaining rather than silently doing.
+  late final double? _speedFloor = minimumRadiusForSpeed(widget.travelSpeed);
+
+  /// Opens wider than the 500m default when the user is moving fast enough
+  /// that 500m could be crossed between two location checks. Defaulting to
+  /// the safe value and explaining it beats showing a hint next to a slider
+  /// already sitting on a number that will not work.
+  double _initialRadius() {
+    const fallback = 500.0;
+    final floor = minimumRadiusForSpeed(widget.travelSpeed);
+    return floor == null || floor < fallback ? fallback : floor;
+  }
 
   @override
   void initState() {
@@ -203,6 +235,52 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
     );
   }
 
+  /// Explains a radius that was widened for the speed the user is travelling
+  /// at, and warns if they then drag it back below what that speed needs.
+  ///
+  /// Silent when standing still or walking, which is most of the time: a note
+  /// that is always on screen is one nobody reads when it matters.
+  Widget _buildSpeedNote(BuildContext context) {
+    final floor = _speedFloor;
+    final speed = widget.travelSpeed;
+    if (floor == null || speed == null) return const SizedBox.shrink();
+
+    final scheme = Theme.of(context).colorScheme;
+    final tooTight = _radius < floor;
+    final asText = floor >= 1000
+        ? '${(floor / 1000).toStringAsFixed(1)} km'
+        : '${floor.round()} m';
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            tooTight ? Icons.warning_amber_rounded : Icons.speed,
+            size: 16,
+            color: tooTight ? scheme.error : scheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              tooTight
+                  ? "You're moving at ${kilometresPerHour(speed)} km/h. Below "
+                      '$asText the alarm can pass your stop between location '
+                      'checks.'
+                  : "You're moving at ${kilometresPerHour(speed)} km/h, so "
+                      'this starts at $asText to give the alarm room to catch '
+                      'you.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: tooTight ? scheme.error : scheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildSearchBar(BuildContext context) {
     return SafeArea(
       child: Padding(
@@ -221,6 +299,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                 child: TextField(
                   controller: _searchController,
                   focusNode: _searchFocus,
+                  autofocus: widget.autofocusSearch,
                   textInputAction: TextInputAction.search,
                   onChanged: _onSearchChanged,
                   onTap: () {
@@ -401,6 +480,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                   divisions: 29,
                   onChanged: (value) => setState(() => _radius = value),
                 ),
+                _buildSpeedNote(context),
                 const SizedBox(height: 4),
                 SizedBox(
                   width: double.infinity,

--- a/lib/services/radius_advice.dart
+++ b/lib/services/radius_advice.dart
@@ -1,0 +1,44 @@
+/// How large an alarm radius has to be to survive the speed you are
+/// travelling at.
+///
+/// The watcher samples your position on an interval, not continuously, so a
+/// radius is only useful if you are still inside it when a sample lands. Cross
+/// a circle faster than the gap between fixes and the whole thing can pass by
+/// unsampled: the alarm never sees you arrive.
+///
+/// Approaching a destination, the watcher is polling on the 20-second band
+/// (500m to 1.5km out) for the stretch that decides this, so the radius needs
+/// to cover roughly `speed x 20s` of travel. That gives:
+///
+/// | Travelling      | Needs at least |
+/// |-----------------|----------------|
+/// | under 25 km/h   | 100 m (the floor) |
+/// | 25 to 50 km/h   | 300 m |
+/// | 50 to 90 km/h   | 500 m |
+/// | over 90 km/h    | 1 km |
+///
+/// Under 25 km/h nothing is needed beyond the existing floor, because within
+/// 500m the interval has already tightened to 10 seconds and 7 m/s only
+/// covers 70m in that time.
+library;
+
+/// Smallest radius, in metres, that is dependable at [speedMetresPerSecond].
+///
+/// Returns null when the speed is unknown, implausible, or slow enough that
+/// the ordinary minimum already covers it — in other words, whenever there is
+/// nothing worth telling the user.
+double? minimumRadiusForSpeed(double? speedMetresPerSecond) {
+  final speed = speedMetresPerSecond;
+  // Negative is the "unknown" convention on some providers, and a stationary
+  // phone reports jitter rather than a clean zero. Anything above about
+  // 400 km/h is a bad fix, not a journey.
+  if (speed == null || speed < 1 || speed > 110) return null;
+
+  if (speed > 25) return 1000;
+  if (speed > 14) return 500;
+  if (speed > 7) return 300;
+  return null;
+}
+
+/// The speed itself, in km/h, for telling the user what was measured.
+int kilometresPerHour(double metresPerSecond) => (metresPerSecond * 3.6).round();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: locreminder
 description: "Never miss your stop. A location-based alarm app built with Flutter."
 publish_to: 'none'
 
-version: 1.6.16+23
+version: 1.7.0+24
 
 environment:
   sdk: '>=3.3.0 <4.0.0'

--- a/test/radius_advice_test.dart
+++ b/test/radius_advice_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locreminder/services/radius_advice.dart';
+
+void main() {
+  group('minimumRadiusForSpeed', () {
+    test('says nothing when the speed is unknown', () {
+      expect(minimumRadiusForSpeed(null), isNull);
+    });
+
+    test('says nothing when standing still or walking', () {
+      // Under 25 km/h the watcher is already polling every 10 seconds by the
+      // time it matters, and the existing 100m floor covers that.
+      expect(minimumRadiusForSpeed(0), isNull);
+      expect(minimumRadiusForSpeed(1.4), isNull); // walking, 5 km/h
+      expect(minimumRadiusForSpeed(6), isNull); // cycling, 21 km/h
+    });
+
+    test('widens through the speed bands', () {
+      expect(minimumRadiusForSpeed(10), 300); // city bus, 36 km/h
+      expect(minimumRadiusForSpeed(20), 500); // highway coach, 72 km/h
+      expect(minimumRadiusForSpeed(30), 1000); // intercity, 108 km/h
+    });
+
+    test('holds at each boundary rather than jumping early', () {
+      expect(minimumRadiusForSpeed(7), isNull);
+      expect(minimumRadiusForSpeed(7.1), 300);
+      expect(minimumRadiusForSpeed(14), 300);
+      expect(minimumRadiusForSpeed(14.1), 500);
+      expect(minimumRadiusForSpeed(25), 500);
+      expect(minimumRadiusForSpeed(25.1), 1000);
+    });
+
+    test('ignores readings no journey could produce', () {
+      // Some providers report a negative speed to mean "unknown", and a bad
+      // fix can invent a few hundred metres per second.
+      expect(minimumRadiusForSpeed(-1), isNull);
+      expect(minimumRadiusForSpeed(200), isNull);
+    });
+
+    test('never asks for more than the slider offers', () {
+      for (var speed = 0.0; speed <= 110; speed += 0.5) {
+        final radius = minimumRadiusForSpeed(speed);
+        if (radius != null) {
+          expect(radius, greaterThanOrEqualTo(100));
+          expect(radius, lessThanOrEqualTo(3000));
+        }
+      }
+    });
+  });
+
+  test('kilometresPerHour converts for display', () {
+    expect(kilometresPerHour(10), 36);
+    expect(kilometresPerHour(27.8), 100);
+  });
+}


### PR DESCRIPTION
Fixes the missed second alarm (two independent causes), plus the mid-screen stuck SnackBar, the two-tap search field, and vibration being suppressed by Do Not Disturb. Adds speed-aware polling and radius advice.

Full reasoning in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)