### PR TITLE
Bound the map camera, and make Signal Blue the actual accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,58 @@
 All notable changes to LocReminder are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Zooming the map out quickly could leave it frozen and take the app down with
+  it. flutter_map turns a pinch into a zoom with `log(scale)`, and its only
+  guard is a clamp against the map's own zoom limits — which this app had
+  never set, making the clamp a no-op. A fast enough gesture reports a scale
+  of zero, `log(0)` is negative infinity, and that went straight into the
+  camera: every projection then worked from a world of zero size, and the
+  resulting NaN spread through the tile and marker maths until nothing could
+  be drawn. Both maps now hold between zoom 2 and 19.
+- The picker's radius circle drifted away from the centre crosshair while the
+  map was being dragged, then jumped back a moment after it stopped. The
+  circle was drawn at the last centre the screen had been told about, and it
+  was only told once the address lookup fired. It now follows the map itself,
+  so the circle and the pin never disagree about where the alarm will go.
+- One unreadable saved alarm — written by an older build, or truncated by the
+  system killing the app mid-write — took the whole list with it and left the
+  app on its loading spinner permanently. Bad records are skipped now, and
+  startup can no longer be stopped by anything it reads.
+- A permission check that the platform refused to answer had the same effect,
+  on the launch screen. Any single check that fails is now read as "not
+  granted" instead of stopping the screen from loading.
+- The alarm test on the reliability screen said "lock your phone now" even
+  when scheduling the test had been refused, which is the one screen where a
+  silent failure is worst. It now says what went wrong.
+- Deleting an alarm, tapping Contact on the About screen with no mail app set
+  up, and opening a vendor settings screen that does not exist could each
+  throw where nothing was catching.
+- The topographic map went blank above zoom 17 rather than blurry.
+  OpenTopoMap does not publish tiles past that level, and the app had not
+  said so, so it kept asking for tiles that will never exist.
+
+### Changed
+- The blue from the launcher icon is now the app's accent everywhere, in both
+  light and dark themes. It was already the seed for the colour scheme, but
+  Material treats a seed as a hue to harmonise rather than a colour to
+  reproduce, so the blue on screen never actually matched the icon. Surfaces
+  are still Material's generated tonal greys; the accent roles are now the
+  icon's own blue, lightened for dark mode so it can carry text.
+
+  It shows up on the alarm switches, the "Add alarm" button, the theme
+  picker, section labels, links and the About screen's app mark. The two
+  small map buttons deliberately went the other way — white with a blue
+  glyph — so that only one control on the map reads as the primary action.
+- Map tiles are darkened with a single filter over the whole layer instead of
+  one per tile. A colour filter allocates an offscreen buffer, and doing that
+  per tile meant dozens of them every frame of a pan or a pinch, at exactly
+  the moment there was least headroom.
+- Tile requests are capped at six connections at a time with a bounded
+  connect attempt, so a flung gesture cannot put a socket in flight per tile.
+
 ## [1.7.1] - 2026-08-23
 
 ### Fixed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,6 +3,12 @@ name: LocReminder
 description: A location alarm whose interface stays out of the way until the moment it matters.
 colors:
   primary-seed: "#2563EB"
+  signal-blue-light: "#2563EB"
+  signal-blue-dark: "#60A5FA"
+  signal-container-light: "#BFDBFE"
+  signal-container-dark: "#1E40AF"
+  aside-light: "#475569"
+  aside-dark: "#94A3B8"
   map-pin-shadow: "rgba(0, 0, 0, 0.28)"
   user-position: "#448AFF"
   banner-paper: "#F5F1EA"
@@ -99,23 +105,45 @@ A single seeded accent over Material 3's generated tonal surfaces, so light and
 dark are one system rather than two palettes.
 
 ### Primary
-- **Signal Blue** (`#2563EB`): the seed for the entire scheme, chosen to match
-  the launcher icon so app and icon read as one product. Appears on the active
-  alarm pin, the radius circle, filled buttons, the focused input border,
-  slider track and thumb, and section labels. Everything else is derived from
-  it by `ColorScheme.fromSeed`.
+- **Signal Blue** (`#2563EB`): taken from the launcher icon so app and icon
+  read as one product. Appears on the active alarm pin, the radius circle,
+  filled buttons and the "Add alarm" button, the alarm switches, the selected
+  theme segment, outlined-button labels, the focused input border, slider
+  track and thumb, links, and section labels.
+
+  It is both the seed for the scheme *and* the literal value of `primary`. The
+  second half is load-bearing: `ColorScheme.fromSeed` treats a seed as a hue
+  to harmonise rather than a colour to reproduce, and returned a muted slate
+  blue, so for several releases the accent on screen was not the icon's blue
+  at all. `AppTheme` now overrides the accent roles with the icon's own ramp
+  and lets `fromSeed` keep every neutral.
+
+  Dark mode uses `#60A5FA` — the same blue two steps lighter, because
+  `#2563EB` is too dense to carry white text on a dark surface. Containers
+  step to `#BFDBFE` / `#DBEAFE` in light and `#1E40AF` / `#1E3A8A` in dark.
 
 ### Neutral
 Surfaces are Material 3's generated tonal roles, not hand-picked greys:
 `surface` for the scaffold, `surfaceContainerLow` for cards,
 `surfaceContainerHigh` for input fills, `surfaceContainerHighest` for inactive
-slider track, `outlineVariant` at 50% for dividers. A paused alarm's pin uses
-`outline` — the same shape as an active one, drained of signal.
+slider track and switch tracks, `outlineVariant` at 50% for dividers. A paused
+alarm's pin uses `outline` — the same shape as an active one, drained of
+signal.
+
+White (and its dark-mode equivalent, `surface`) is the app's other half: the
+two small map buttons, the search bar and the menu button are surface-filled
+with a Signal Blue glyph, which is what keeps "Add alarm" the only control on
+the map reading as the primary action.
 
 ### Tertiary
 - **Position Blue** (`#448AFF`): the user's own location dot and its accuracy
   circle. Deliberately distinct from Signal Blue so "where I am" never reads as
   "where the alarm is".
+- **Slate** (`#475569` light, `#94A3B8` dark, with `#E2E8F0` / `#334155`
+  containers): the informational callouts on the onboarding and reliability
+  screens. A neutral, not a hue — Material's generated tertiary for this seed
+  lands in the pinks, which would be the second accent the system does not
+  want.
 - **Banner Paper** (`#F5F1EA`): a fixed light card behind the About screen's
   Free Palestine artwork, which is dark ink on transparency and would otherwise
   vanish in dark mode.
@@ -229,6 +257,12 @@ below its tip and would float above the radius circle it marks.
 change must keep the tip on the anchor, or the alarm appears to be somewhere it
 is not.
 
+**The Bounded Camera Rule.** Every map states a `minZoom` and a `maxZoom`.
+flutter_map's only guard on a pinch is a clamp against those two numbers, and
+leaving them unset makes it a no-op — a fast enough gesture reports a scale of
+zero, and `log(0)` puts negative infinity into the camera, from which nothing
+recovers. This is not a preference about how far out someone may zoom.
+
 ## Components
 
 ### Buttons
@@ -275,11 +309,19 @@ are inverted by a luminance matrix that preserves hue, so the map reads dark
 rather than as a glaring white rectangle. Topographic and cycle styles are left
 alone: inverting shaded relief turns hills inside out.
 
+The filter is applied once, to the assembled layer, not through `tileBuilder`.
+Per tile it would be one offscreen buffer each, every frame of every gesture.
+
+Every map holds between zoom 2 and 19, and each style declares the deepest
+zoom its server actually publishes. Both are correctness, not taste: see
+**The Bounded Camera Rule**.
+
 ## Do's and Don'ts
 
 ### Do:
-- **Do** keep Signal Blue (`#2563EB`) as the only accent, and derive everything
-  else from the seeded scheme.
+- **Do** keep Signal Blue (`#2563EB`) as the only accent, and derive every
+  neutral from the seeded scheme. Set the accent roles literally; never assume
+  `fromSeed` will hand back the colour you gave it.
 - **Do** give anything floating over the map a shadow with both offset and
   blur.
 - **Do** keep interactive targets at 48px or more even while spacing stays
@@ -301,3 +343,7 @@ alone: inverting shaded relief turns hills inside out.
   misaligned.
 - **Don't** cover the OpenStreetMap attribution. Its visibility is a licence
   condition, not a layout preference.
+- **Don't** build a `FlutterMap` without `minZoom` and `maxZoom`. See **The
+  Bounded Camera Rule** — the omission is a crash, not a looser map.
+- **Don't** filter tiles through `tileBuilder`. A colour filter is an
+  offscreen buffer; buy one for the layer, not one per tile.

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -27,9 +27,21 @@ class _AboutScreenState extends State<AboutScreen> {
   static final _palestine =
       Uri.parse('https://revolutionarypapers.org/journal/free-palestine/');
 
+  /// Opens a link, saying so when it cannot be opened.
+  ///
+  /// `launchUrl` reports "no" two different ways — false, and a thrown
+  /// PlatformException when nothing on the device claims the scheme at all.
+  /// The second is the likely one here: `mailto:` on a phone with no mail app
+  /// set up throws, and only the first was handled, so tapping Contact did
+  /// nothing at all and said nothing about why.
   Future<void> _open(BuildContext context, Uri uri) async {
     final messenger = ScaffoldMessenger.of(context);
-    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    bool launched;
+    try {
+      launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      launched = false;
+    }
     if (!launched) {
       messenger.showSnackBar(
         SnackBar(content: Text('Could not open $uri')),
@@ -49,17 +61,28 @@ class _AboutScreenState extends State<AboutScreen> {
           Center(
             child: Column(
               children: [
+                // Solid Signal Blue with a white pin, standing in for the
+                // launcher icon: this is the one place in the app that is
+                // simply the product's mark, so it carries the accent at full
+                // strength rather than the pale container tone.
                 Container(
                   width: 96,
                   height: 96,
                   decoration: BoxDecoration(
-                    color: scheme.primaryContainer,
+                    color: scheme.primary,
                     borderRadius: BorderRadius.circular(28),
+                    boxShadow: [
+                      BoxShadow(
+                        color: scheme.primary.withValues(alpha: 0.32),
+                        blurRadius: 20,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
                   ),
                   child: Icon(
                     Icons.location_on,
                     size: 52,
-                    color: scheme.onPrimaryContainer,
+                    color: scheme.onPrimary,
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -113,7 +136,11 @@ class _AboutScreenState extends State<AboutScreen> {
                   subtitle: const Text('zaifears'),
                 ),
                 const Divider(height: 1),
+                // Signal Blue on the icons rather than the row: these three
+                // leave the app, and the accent is what marks them as links
+                // without needing underlines or a fourth type style.
                 ListTile(
+                  iconColor: scheme.primary,
                   leading: const Icon(Icons.language),
                   title: const Text('Website'),
                   subtitle: const Text('shahoriar.bd'),
@@ -122,6 +149,7 @@ class _AboutScreenState extends State<AboutScreen> {
                 ),
                 const Divider(height: 1),
                 ListTile(
+                  iconColor: scheme.primary,
                   leading: const Icon(Icons.code),
                   title: const Text('GitHub'),
                   subtitle: const Text('github.com/zaifears/locreminder'),
@@ -130,6 +158,7 @@ class _AboutScreenState extends State<AboutScreen> {
                 ),
                 const Divider(height: 1),
                 ListTile(
+                  iconColor: scheme.primary,
                   leading: const Icon(Icons.mail_outline),
                   title: const Text('Contact'),
                   subtitle: const Text('shahoriar.connect@gmail.com'),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -82,16 +82,27 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     }
   }
 
+  /// Everything the map needs before it can be shown.
+  ///
+  /// The `finally` is the point: each step here talks to storage or to the
+  /// platform, and anything that throws on the way used to leave `_loading`
+  /// true forever — a permanent spinner instead of a map, on a device where
+  /// one of these calls happens to misbehave. Clearing the flag regardless
+  /// means the worst case is a map missing some state, which the app already
+  /// recovers from on the next resume.
   Future<void> _bootstrap() async {
-    final style = await MapStyleStore.load();
-    if (mounted) setState(() => _mapStyle = style);
-    final alarms = await _repository.loadAll();
-    if (mounted) setState(() => _alarms = alarms);
-    await _reconcileTriggeredAlarms();
-    await _refreshRingingState();
-    await _refreshPermissions();
-    await _locateUser();
-    if (mounted) setState(() => _loading = false);
+    try {
+      final style = await MapStyleStore.load();
+      if (mounted) setState(() => _mapStyle = style);
+      final alarms = await _repository.loadAll();
+      if (mounted) setState(() => _alarms = alarms);
+      await _reconcileTriggeredAlarms();
+      await _refreshRingingState();
+      await _refreshPermissions();
+      await _locateUser();
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
   }
 
   Future<void> _refreshPermissions() async {
@@ -319,7 +330,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   Future<void> _deleteAlarm(LocationAlarm alarm) async {
     final index = _alarms.indexWhere((a) => a.id == alarm.id);
-    await _nativeBridge.removeAlarm(alarm.id);
+    try {
+      await _nativeBridge.removeAlarm(alarm.id);
+    } on PlatformException catch (_) {
+      // Same reasoning as _toggleAlarm: the delete still stands on this side,
+      // and the next resume reconciles the native store. Letting this throw
+      // instead left the row on screen with no explanation.
+    }
     if (!mounted) return;
 
     setState(() => _alarms = _alarms.where((a) => a.id != alarm.id).toList());
@@ -491,6 +508,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               options: MapOptions(
                 initialCenter: _initialPosition,
                 initialZoom: 14,
+                // Without these flutter_map's zoom clamp is a no-op and a
+                // fast pinch can drive the camera to negative infinity; see
+                // [mapMinZoom].
+                minZoom: mapMinZoom,
+                maxZoom: mapMaxZoom,
               ),
               children: [
                 buildTileLayer(context, style: _mapStyle),
@@ -541,6 +563,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   /// the map, and buttons floating over the rows are just something to hit by
   /// accident.
   Widget _buildMapControls(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return Positioned(
       right: 16,
       bottom: _mapControlsBottomInset(context),
@@ -560,6 +583,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               FloatingActionButton.small(
                 heroTag: 'style',
                 tooltip: 'Map style',
+                // White with a blue glyph, the inverse of the extended button
+                // below. Only one control in this column is the primary
+                // action, and filling all three in Signal Blue would say
+                // otherwise — as well as putting three saturated blocks over
+                // a map the design system asks to keep readable.
+                backgroundColor: scheme.surface,
+                foregroundColor: scheme.primary,
                 onPressed: _pickMapStyle,
                 child: const Icon(Icons.layers_outlined),
               ),
@@ -567,14 +597,19 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               FloatingActionButton.small(
                 heroTag: 'locate',
                 tooltip: 'Centre on my location',
+                backgroundColor: scheme.surface,
+                foregroundColor: scheme.primary,
                 // Getting a real fix can take a few seconds, so the button
                 // has to show it is working rather than looking inert.
                 onPressed: _locating ? null : () => _locateUser(recenter: true),
                 child: _locating
-                    ? const SizedBox(
+                    ? SizedBox(
                         width: 18,
                         height: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: scheme.primary,
+                        ),
                       )
                     : const Icon(Icons.my_location),
               ),

--- a/lib/screens/location_picker_screen.dart
+++ b/lib/screens/location_picker_screen.dart
@@ -190,23 +190,16 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
             options: MapOptions(
               initialCenter: widget.initialCenter,
               initialZoom: 15,
+              // See [mapMinZoom]: unbounded zoom is what lets a fast pinch
+              // put a non-finite value into the camera.
+              minZoom: mapMinZoom,
+              maxZoom: mapMaxZoom,
               onPositionChanged: _onMapMoved,
               onTap: (_, __) => _searchFocus.unfocus(),
             ),
             children: [
               buildTileLayer(context, style: _mapStyle),
-              CircleLayer(
-                circles: [
-                  CircleMarker(
-                    point: _center,
-                    radius: _radius,
-                    useRadiusInMeter: true,
-                    color: scheme.primary.withValues(alpha: 0.12),
-                    borderColor: scheme.primary.withValues(alpha: 0.7),
-                    borderStrokeWidth: 2,
-                  ),
-                ],
-              ),
+              _RadiusCircle(radius: _radius, color: scheme.primary),
             ],
           ),
 
@@ -495,6 +488,38 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// The radius circle under the picker's fixed crosshair.
+///
+/// It reads the centre from the live [MapCamera] rather than being handed a
+/// coordinate by the screen, because the screen only learns the new centre
+/// through `onPositionChanged` and rebuilding the whole picker on every frame
+/// of a drag to pass it down would be wasteful. Taking it from the camera
+/// here rebuilds one layer instead — and fixes the circle drifting off the
+/// crosshair mid-drag and snapping back once the address lookup settled,
+/// which made the pin look like it was not where the alarm would go.
+class _RadiusCircle extends StatelessWidget {
+  const _RadiusCircle({required this.radius, required this.color});
+
+  final double radius;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleLayer(
+      circles: [
+        CircleMarker(
+          point: MapCamera.of(context).center,
+          radius: radius,
+          useRadiusInMeter: true,
+          color: color.withValues(alpha: 0.12),
+          borderColor: color.withValues(alpha: 0.7),
+          borderStrokeWidth: 2,
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/reliability_screen.dart
+++ b/lib/screens/reliability_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../services/native_bridge.dart';
 import '../services/oem_service.dart';
@@ -84,7 +85,25 @@ class _ReliabilityScreenState extends State<ReliabilityScreen> with WidgetsBindi
 
     if (confirmed != true || !mounted) return;
 
-    await _nativeBridge.triggerTestAlarm(delaySeconds: 15);
+    // Scheduling can be refused — an exact-alarm restriction, a vendor policy
+    // — and this is the one screen where a silent failure is the worst
+    // possible outcome: the user locks their phone, nothing rings, and they
+    // conclude the alarm is broken when it was the test that never started.
+    try {
+      await _nativeBridge.triggerTestAlarm(delaySeconds: 15);
+    } on PlatformException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Could not start the test (${e.message ?? e.code}). Work through '
+            'the steps above, then try again.',
+          ),
+          duration: const Duration(seconds: 6),
+        ),
+      );
+      return;
+    }
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(

--- a/lib/services/alarm_repository.dart
+++ b/lib/services/alarm_repository.dart
@@ -10,12 +10,28 @@ import '../models/location_alarm.dart';
 class AlarmRepository {
   static const _prefsKey = 'location_alarms';
 
+  /// Reads the saved alarms, skipping any record that will not parse.
+  ///
+  /// One bad entry used to take the whole list with it: `loadAll` threw, the
+  /// exception escaped the home screen's bootstrap, and the app sat on its
+  /// loading spinner for good with no way back short of clearing its data.
+  /// A record written by an older build, or truncated by a kill mid-write, is
+  /// a reason to lose that alarm — not every alarm and the app with it.
   Future<List<LocationAlarm>> loadAll() async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getStringList(_prefsKey) ?? const [];
-    return raw
-        .map((s) => LocationAlarm.fromJson(jsonDecode(s) as Map<String, dynamic>))
-        .toList();
+
+    final alarms = <LocationAlarm>[];
+    for (final entry in raw) {
+      try {
+        alarms.add(
+          LocationAlarm.fromJson(jsonDecode(entry) as Map<String, dynamic>),
+        );
+      } catch (_) {
+        continue;
+      }
+    }
+    return alarms;
   }
 
   Future<void> saveAll(List<LocationAlarm> alarms) async {

--- a/lib/services/oem_service.dart
+++ b/lib/services/oem_service.dart
@@ -439,8 +439,26 @@ class OemService {
     );
   }
 
-  Future<bool> openAutoStartSettings() => _nativeBridge.openAutoStartSettings();
-  Future<bool> openAppSettings() => _nativeBridge.openAppSettings();
+  /// Both report failure rather than throwing, the same way [profile] does.
+  ///
+  /// A vendor screen that is not there, or refuses the intent, is an ordinary
+  /// outcome on the phones this page exists for — and the caller already has
+  /// somewhere to go when one of these returns false.
+  Future<bool> openAutoStartSettings() async {
+    try {
+      return await _nativeBridge.openAutoStartSettings();
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  Future<bool> openAppSettings() async {
+    try {
+      return await _nativeBridge.openAppSettings();
+    } on PlatformException {
+      return false;
+    }
+  }
 
   _VendorProfile? _lookup(String key) {
     if (key.isEmpty) return null;

--- a/lib/services/permission_service.dart
+++ b/lib/services/permission_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart' as ph;
 
 import 'native_bridge.dart';
@@ -49,13 +50,34 @@ class PermissionService {
 
   final NativeBridge _nativeBridge;
 
+  /// Reads every permission the app depends on, degrading one answer rather
+  /// than the whole call when the platform will not say.
+  ///
+  /// Six calls across two plugins and a method channel, and this runs on the
+  /// startup path: an exception from any one of them used to propagate out of
+  /// here, leaving whichever screen asked stuck on its loading spinner with
+  /// no route forward — including the launch gate, which decides between
+  /// onboarding and the map. Treating an unanswerable check as "not granted"
+  /// is both the safe reading and a recoverable one: every caller re-checks
+  /// when the app is resumed.
   Future<PermissionStatusSummary> currentStatus() async {
-    final serviceEnabled = await _nativeBridge.isLocationEnabled();
-    final foreground = await ph.Permission.locationWhenInUse.status;
-    final background = await ph.Permission.locationAlways.status;
-    final notifications = await ph.Permission.notification.status;
-    final fullScreenIntent = await _nativeBridge.canUseFullScreenIntent();
-    final batteryOptimization = await _nativeBridge.isIgnoringBatteryOptimizations();
+    final serviceEnabled = await _ask(_nativeBridge.isLocationEnabled, false);
+    final foreground = await _ask(
+      () => ph.Permission.locationWhenInUse.status,
+      ph.PermissionStatus.denied,
+    );
+    final background = await _ask(
+      () => ph.Permission.locationAlways.status,
+      ph.PermissionStatus.denied,
+    );
+    final notifications = await _ask(
+      () => ph.Permission.notification.status,
+      ph.PermissionStatus.denied,
+    );
+    final fullScreenIntent =
+        await _ask(_nativeBridge.canUseFullScreenIntent, true);
+    final batteryOptimization =
+        await _ask(_nativeBridge.isIgnoringBatteryOptimizations, false);
 
     return PermissionStatusSummary(
       locationServiceEnabled: serviceEnabled,
@@ -65,6 +87,17 @@ class PermissionService {
       fullScreenIntentAllowed: fullScreenIntent,
       batteryOptimizationDisabled: batteryOptimization,
     );
+  }
+
+  /// Runs one platform check, falling back if it cannot be answered.
+  static Future<T> _ask<T>(Future<T> Function() check, T fallback) async {
+    try {
+      return await check();
+    } on PlatformException {
+      return fallback;
+    } on MissingPluginException {
+      return fallback;
+    }
   }
 
   Future<bool> requestForegroundLocation() async {

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,17 +1,75 @@
 import 'package:flutter/material.dart';
 
+/// The app's colour system: Material 3 tonal *surfaces*, but hand-pinned
+/// *accents*.
+///
+/// `ColorScheme.fromSeed` is still what generates every neutral, because
+/// getting light and dark surfaces to agree is exactly what it is good at.
+/// What it is not good at is keeping a brand colour recognisable: it treats
+/// the seed as a hue to harmonise, not a colour to reproduce, so
+/// `#2563EB` came back as a muted slate blue and the accent on screen never
+/// actually matched the launcher icon. The accent roles below are therefore
+/// set from the icon's own palette, so the blue the user sees in their app
+/// drawer is the blue they see inside the app.
 class AppTheme {
   AppTheme._();
 
-  /// Matches the blue in the launcher icon so the app and its icon read as
-  /// one product.
+  // ------------------------------------------------------------ Signal Blue
+  //
+  // One hue, sampled from the launcher icon and stepped light to dark. Light
+  // mode leans on the mid and pale steps, dark mode on the lighter ones —
+  // #2563EB is too dense to carry text on a dark surface, so dark mode's
+  // accent is the same blue two steps up rather than a different colour.
+
+  static const _blue100 = Color(0xFFDBEAFE);
+  static const _blue200 = Color(0xFFBFDBFE);
+  static const _blue300 = Color(0xFF93C5FD);
+  static const _blue400 = Color(0xFF60A5FA);
+  static const _blue800 = Color(0xFF1E40AF);
+  static const _blue900 = Color(0xFF1E3A8A);
+  static const _blue950 = Color(0xFF172554);
+
+  /// Signal Blue, straight off the launcher icon. The app's only accent.
   static const seed = Color(0xFF2563EB);
+
+  // Quiet blue-grey for the informational callouts that must read as an aside
+  // rather than an action. Material's generated tertiary lands in the pinks
+  // for this seed, which is a second hue the design system does not want.
+  static const _slate200 = Color(0xFFE2E8F0);
+  static const _slate400 = Color(0xFF94A3B8);
+  static const _slate600 = Color(0xFF475569);
+  static const _slate700 = Color(0xFF334155);
+  static const _slate800 = Color(0xFF1E293B);
+  static const _slate900 = Color(0xFF0F172A);
 
   static ThemeData light() => _build(Brightness.light);
   static ThemeData dark() => _build(Brightness.dark);
 
+  /// Replaces the generated accent roles with the icon's blue, leaving every
+  /// surface, outline and error role exactly as `fromSeed` produced it.
+  static ColorScheme _accented(ColorScheme scheme) {
+    final isDark = scheme.brightness == Brightness.dark;
+    return scheme.copyWith(
+      primary: isDark ? _blue400 : seed,
+      onPrimary: isDark ? _blue950 : Colors.white,
+      primaryContainer: isDark ? _blue800 : _blue200,
+      onPrimaryContainer: isDark ? _blue100 : _blue900,
+      secondary: isDark ? _blue300 : _blue800,
+      onSecondary: isDark ? _blue950 : Colors.white,
+      secondaryContainer: isDark ? _blue900 : _blue100,
+      onSecondaryContainer: isDark ? _blue100 : _blue900,
+      tertiary: isDark ? _slate400 : _slate600,
+      onTertiary: isDark ? _slate900 : Colors.white,
+      tertiaryContainer: isDark ? _slate700 : _slate200,
+      onTertiaryContainer: isDark ? _slate200 : _slate800,
+      surfaceTint: isDark ? _blue400 : seed,
+    );
+  }
+
   static ThemeData _build(Brightness brightness) {
-    final scheme = ColorScheme.fromSeed(seedColor: seed, brightness: brightness);
+    final scheme = _accented(
+      ColorScheme.fromSeed(seedColor: seed, brightness: brightness),
+    );
     final base = ThemeData(useMaterial3: true, colorScheme: scheme);
 
     return base.copyWith(
@@ -42,6 +100,13 @@ class AppTheme {
           padding: const EdgeInsets.symmetric(horizontal: 24),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+          // An outlined button is the secondary action, but it is still an
+          // action: tinting the label and icon keeps the accent doing the
+          // "this is tappable" work instead of leaving a grey ghost button.
+          // The edge stays neutral — Material resolves this to its disabled
+          // colour on its own, and onboarding leans on that to show a
+          // permission as already granted.
+          foregroundColor: scheme.primary,
         ),
       ),
       textButtonTheme: TextButtonThemeData(
@@ -88,9 +153,60 @@ class AppTheme {
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
         insetPadding: const EdgeInsets.all(16),
       ),
+      // Signal Blue with a white glyph, which is what makes "Add alarm" read
+      // as the one primary action on the map. The two small utility buttons
+      // above it deliberately invert that — see `_buildMapControls`.
       floatingActionButtonTheme: FloatingActionButtonThemeData(
         elevation: 4,
+        backgroundColor: scheme.primary,
+        foregroundColor: scheme.onPrimary,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      ),
+      // On is Signal Blue carrying a white thumb; off is a neutral track with
+      // an outline, so "off" reads as a switch at rest rather than as a
+      // disabled control. These are Material 3's own roles, pinned rather
+      // than inherited: this switch is what arms and disarms an alarm, and it
+      // is the one control in the app whose colour is load-bearing, so it
+      // should not be free to drift with a future Material default.
+      switchTheme: SwitchThemeData(
+        thumbColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            if (states.contains(WidgetState.selected)) return scheme.surface;
+            return scheme.onSurface.withValues(alpha: 0.38);
+          }
+          if (states.contains(WidgetState.selected)) return scheme.onPrimary;
+          return scheme.outline;
+        }),
+        trackColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return scheme.onSurface.withValues(alpha: 0.12);
+          }
+          if (states.contains(WidgetState.selected)) return scheme.primary;
+          return scheme.surfaceContainerHighest;
+        }),
+        trackOutlineColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.selected)) return Colors.transparent;
+          return scheme.outline;
+        }),
+      ),
+      // The theme picker is the one segmented control in the app, and it is
+      // itself a preview of the choice being made — so the selected segment
+      // is the accent at full strength rather than a pale container.
+      segmentedButtonTheme: SegmentedButtonThemeData(
+        style: ButtonStyle(
+          backgroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.selected)) return scheme.primary;
+            return Colors.transparent;
+          }),
+          foregroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.selected)) return scheme.onPrimary;
+            return scheme.onSurfaceVariant;
+          }),
+          iconColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.selected)) return scheme.onPrimary;
+            return scheme.onSurfaceVariant;
+          }),
+        ),
       ),
       dialogTheme: DialogThemeData(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
@@ -106,6 +222,7 @@ class AppTheme {
         inactiveTrackColor: scheme.surfaceContainerHighest,
         thumbColor: scheme.primary,
       ),
+      progressIndicatorTheme: ProgressIndicatorThemeData(color: scheme.primary),
       pageTransitionsTheme: const PageTransitionsTheme(
         builders: {
           TargetPlatform.android: PredictiveBackPageTransitionsBuilder(),

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -21,14 +21,15 @@ class AppDrawer extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
               child: Row(
                 children: [
+                  // The same mark as the About screen's, at drawer size.
                   Container(
                     width: 48,
                     height: 48,
                     decoration: BoxDecoration(
-                      color: scheme.primaryContainer,
+                      color: scheme.primary,
                       shape: BoxShape.circle,
                     ),
-                    child: Icon(Icons.location_on, color: scheme.onPrimaryContainer),
+                    child: Icon(Icons.location_on, color: scheme.onPrimary),
                   ),
                   const SizedBox(width: 14),
                   Column(
@@ -54,6 +55,7 @@ class AppDrawer extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12),
               child: ListTile(
+                iconColor: scheme.primary,
                 leading: const Icon(Icons.health_and_safety_outlined),
                 title: Text(text.drawerReliability),
                 subtitle: Text(text.drawerReliabilitySubtitle),
@@ -68,6 +70,7 @@ class AppDrawer extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12),
               child: ListTile(
+                iconColor: scheme.primary,
                 leading: const Icon(Icons.settings_outlined),
                 title: Text(text.drawerSettings),
                 onTap: () {
@@ -81,6 +84,7 @@ class AppDrawer extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12),
               child: ListTile(
+                iconColor: scheme.primary,
                 leading: const Icon(Icons.info_outline),
                 title: Text(text.drawerAbout),
                 onTap: () {

--- a/lib/widgets/map_tiles.dart
+++ b/lib/widgets/map_tiles.dart
@@ -4,11 +4,30 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
 import 'package:http/retry.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 const _userAgentPackageName = 'com.zaifears.locreminder';
 const _styleKey = 'map_style';
+
+/// Hard limits on how far the map may be zoomed, applied to every map in the
+/// app.
+///
+/// These are not a styling preference — they are the only thing standing
+/// between a fast pinch and a broken camera. flutter_map turns a pinch into a
+/// zoom with `startZoom + log(scale) / ln2`, and its only guard is
+/// `zoom.clamp(minZoom ?? -infinity, maxZoom ?? infinity)`. Leave the bounds
+/// unset and that clamp is a no-op, so the moment a fling drives the reported
+/// gesture scale to zero, `log(0)` puts negative infinity straight into the
+/// camera: every projection then divides by a zero world size, NaN spreads
+/// through the tile and marker maths, and the map stops responding until the
+/// process dies. With bounds set, the same gesture simply lands on [mapMinZoom].
+///
+/// 2 is a whole-world view on a phone; 19 is the deepest level the tile
+/// sources actually carry.
+const double mapMinZoom = 2;
+const double mapMaxZoom = 19;
 
 /// A raster tile source.
 ///
@@ -25,6 +44,7 @@ enum MapStyle {
     urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
     attribution: '© OpenStreetMap',
     invertsForDarkTheme: true,
+    maxNativeZoom: 19,
   ),
   humanitarian(
     id: 'humanitarian',
@@ -33,6 +53,7 @@ enum MapStyle {
     urlTemplate: 'https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png',
     attribution: '© OpenStreetMap · HOT',
     invertsForDarkTheme: true,
+    maxNativeZoom: 19,
   ),
   topographic(
     id: 'topographic',
@@ -42,6 +63,9 @@ enum MapStyle {
     attribution: '© OpenStreetMap · OpenTopoMap (CC-BY-SA)',
     // Inverting shaded relief turns hills inside out, so leave it alone.
     invertsForDarkTheme: false,
+    // OpenTopoMap stops at 17. Without saying so, zooming past it asked for
+    // tiles that will never exist and the map went blank rather than blurry.
+    maxNativeZoom: 17,
   ),
   cycle(
     id: 'cyclosm',
@@ -50,6 +74,7 @@ enum MapStyle {
     urlTemplate: 'https://a.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
     attribution: '© OpenStreetMap · CyclOSM',
     invertsForDarkTheme: false,
+    maxNativeZoom: 19,
   );
 
   const MapStyle({
@@ -59,6 +84,7 @@ enum MapStyle {
     required this.urlTemplate,
     required this.attribution,
     required this.invertsForDarkTheme,
+    required this.maxNativeZoom,
   });
 
   final String id;
@@ -67,6 +93,10 @@ enum MapStyle {
   final String urlTemplate;
   final String attribution;
   final bool invertsForDarkTheme;
+
+  /// The deepest zoom this source actually renders. Past it flutter_map
+  /// scales the last real tile instead of requesting one that 404s.
+  final int maxNativeZoom;
 
   static MapStyle fromId(String? id) =>
       values.firstWhere((s) => s.id == id, orElse: () => standard);
@@ -105,8 +135,19 @@ const _darkTileFilter = ColorFilter.matrix(<double>[
 /// 5xx and transport failures are retried; 429 deliberately is not.
 /// OpenStreetMap's tile policy treats that as "back off", and retrying
 /// through it would be the sort of behaviour that gets an app blocked.
+///
+/// The connection cap is the other half of that. Dart's `HttpClient` opens as
+/// many sockets per host as it is asked to and will wait indefinitely to
+/// connect each one, so a burst of tile requests — a fast zoom is exactly
+/// that — could put a socket per tile in flight at once. Six at a time, each
+/// with a bounded connect attempt, is what a browser does and keeps the app
+/// inside OpenStreetMap's tile policy while a gesture is being flung about.
 final http.Client _tileClient = RetryClient(
-  http.Client(),
+  IOClient(
+    HttpClient()
+      ..connectionTimeout = const Duration(seconds: 10)
+      ..maxConnectionsPerHost = 6,
+  ),
   retries: 3,
   when: (response) => response.statusCode >= 500,
   whenError: (error, _) =>
@@ -119,23 +160,30 @@ final http.Client _tileClient = RetryClient(
 
 /// Shared tile layer, so both map screens stay consistent and neither forgets
 /// the attribution, the User-Agent or the retry behaviour.
-TileLayer buildTileLayer(BuildContext context, {MapStyle style = MapStyle.standard}) {
+Widget buildTileLayer(BuildContext context, {MapStyle style = MapStyle.standard}) {
   final isDark = Theme.of(context).brightness == Brightness.dark;
-  final invert = isDark && style.invertsForDarkTheme;
 
-  return TileLayer(
+  final layer = TileLayer(
     urlTemplate: style.urlTemplate,
     userAgentPackageName: _userAgentPackageName,
     tileProvider: NetworkTileProvider(httpClient: _tileClient),
+    maxNativeZoom: style.maxNativeZoom,
     // Without this a tile that failed stays failed for the lifetime of the
     // map, even once the network is back. Evicting it means panning away and
     // back is enough to trigger a fresh attempt.
     evictErrorTileStrategy: EvictErrorTileStrategy.notVisibleRespectMargin,
-    tileBuilder: invert
-        ? (context, tileWidget, tile) =>
-            ColorFiltered(colorFilter: _darkTileFilter, child: tileWidget)
-        : null,
   );
+
+  if (!isDark || !style.invertsForDarkTheme) return layer;
+
+  // One filter over the assembled layer, not `tileBuilder`.
+  //
+  // `tileBuilder` runs per tile, and a colour filter is a `saveLayer` — an
+  // offscreen render target. Per tile that is dozens of them allocated and
+  // composited every frame of a pan or a pinch, and the count grows with how
+  // much map is on screen, which is precisely when there is least headroom.
+  // Filtering the layer once costs exactly one, whatever the tile count.
+  return ColorFiltered(colorFilter: _darkTileFilter, child: layer);
 }
 
 /// OpenStreetMap's licence requires visible attribution wherever tiles show,


### PR DESCRIPTION
## The zoom crash

Zooming out fast could freeze the map and take the app down with it.

flutter_map turns a pinch into a zoom with `startZoom + math.log(scale) / math.ln2`, and its only guard is:

```dart
double clampZoom(double zoom) => zoom.clamp(
  minZoom ?? double.negativeInfinity,
  maxZoom ?? double.infinity,
);
```

Neither map set those bounds, so the clamp was a no-op. A fast enough gesture reports `scale == 0.0`, `log(0)` is negative infinity, and that goes straight into the camera — every projection then works from a world of zero size, and the resulting NaN spreads through the tile and marker maths until nothing can be drawn. flutter_map's `MapCamera` constructor asserts the zoom is finite, but assertions are stripped from a release build, so it failed silently rather than loudly.

Both maps now hold between zoom 2 and 19. Every existing `mapController.move()` targets 14–16, so nothing gets clamped unexpectedly.

Two things that made the same gesture worse:

- **Dark mode filtered every tile individually** through `tileBuilder`. A colour filter is a `saveLayer` — an offscreen render target — so that was dozens allocated and composited every frame of a pan or pinch, worst exactly when the most map is on screen. Now one filter over the assembled layer.
- **Tile fetches were uncapped.** Dart's `HttpClient` opens unlimited sockets per host and waits indefinitely to connect each one, so a flung gesture could put a socket in flight per tile. Capped at 6 with a bounded connect attempt, which also keeps the app inside OpenStreetMap's tile policy.

## Other bugs found while auditing

| Where | Problem |
|---|---|
| `location_picker_screen.dart` | The radius circle drifted off the centre crosshair during a drag, then snapped back ~700ms later. It was drawn at the last centre the screen had been told about, and it was only told once the address lookup fired. Now reads the live `MapCamera`. |
| `alarm_repository.dart` | One unparseable saved alarm threw and took the whole list with it. The exception escaped `_bootstrap`, `_loading` stayed true, and the app sat on its spinner permanently — no way out but clearing app data. |
| `home_screen.dart` | Same failure mode from any other bootstrap step. Now `finally`-guarded. |
| `permission_service.dart` | Six platform calls, unguarded, **on the launch gate**. Any one throwing froze the app before it drew a screen. Each check now degrades to "not granted" independently. |
| `reliability_screen.dart` | The alarm test said "lock your phone now" even when scheduling had been refused — on the one screen where a silent failure is worst. |
| `home_screen.dart`, `about_screen.dart`, `oem_service.dart` | Delete-alarm, `mailto:` with no mail app, and vendor-settings intents could each throw uncaught. |
| `map_tiles.dart` | Topographic went **blank** above z17 instead of blurry — OpenTopoMap doesn't publish past 17 and nothing said so, so it kept requesting tiles that will never exist. Now declares per-style `maxNativeZoom`. |

## The theme

`#2563EB` was already the seed, but `ColorScheme.fromSeed` treats a seed as a *hue to harmonise*, not a colour to reproduce — it was returning a muted slate blue, so **the launcher icon's blue was never actually on screen.**

`fromSeed` still generates every neutral surface. The accent roles are now set from the icon's own ramp: `#2563EB` in light, `#60A5FA` in dark (the same blue two steps lighter — `#2563EB` can't carry white text on a dark surface).

Visible on: alarm switches (blue track + white thumb on, neutral track + outline off), **Add alarm** (solid blue), the light/dark/system picker, About (solid blue app mark, blue link icons), the drawer, section labels, slider, focused inputs, map pin and radius circle.

The two small map buttons deliberately went the other way — white with a blue glyph — so only one control on the map reads as the primary action, and you don't get three saturated blocks over a map the design system asks to keep readable.

Material's generated `tertiary` for this seed lands in the **pinks**, which is the second accent DESIGN.md's One Accent Rule forbids, so that role is a slate neutral now. The `#448AFF` position dot is untouched, per the documented rule that it stays distinct from Signal Blue.

`DESIGN.md` and `CHANGELOG.md` are updated, including a new **Bounded Camera Rule** so the `minZoom` omission can't come back.

## Verification

Not built locally — there's no Flutter SDK on the machine this was written on. Every flutter_map API touched was checked against its published source and docs (`MapCamera.of`, `maxNativeZoom`, the `MapOptions` zoom defaults, and the children-in-a-Stack layout that makes the `ColorFiltered` wrapper safe). **This PR's own run of `flutter analyze` and `flutter test` inside the F-Droid buildserver image is the first real compile.**

`python3 tool/gen_locale.py --check` passes locally, so the generated-strings gate is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
